### PR TITLE
Allow search variants to be configurable.

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -42,7 +42,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
-          composer-options: "--prefer-dist"
+          composer-options: "--prefer-dist --no-cache"
 
       - name: Execute tests
         run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
-          composer-options: "--prefer-dist"
+          composer-options: "--prefer-dist --no-cache"
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/src/Concerns/ConditionallySearchingWildcard.php
+++ b/src/Concerns/ConditionallySearchingWildcard.php
@@ -12,6 +12,26 @@ trait ConditionallySearchingWildcard
     public $wildcardSearching = null;
 
     /**
+     * Widlcard search variants.
+     *
+     * @var array|null
+     */
+    public $wildcardSearchVariants = null;
+
+    /**
+     * Set wildcard search variants.
+     *
+     * @param  array  $searchVariants
+     * @return $this
+     */
+    public function wildcardSearchVariants(?array $searchVariants)
+    {
+        $this->wildcardSearchVariants = $searchVariants;
+
+        return $this;
+    }
+
+    /**
      * Set wildcard searching status.
      *
      * @return $this

--- a/src/Concerns/ConditionallySearchingWildcard.php
+++ b/src/Concerns/ConditionallySearchingWildcard.php
@@ -22,6 +22,7 @@ trait ConditionallySearchingWildcard
      * Set wildcard search variants.
      *
      * @param  array  $searchVariants
+     *
      * @return $this
      */
     public function wildcardSearchVariants(?array $searchVariants)

--- a/src/Keyword.php
+++ b/src/Keyword.php
@@ -60,7 +60,8 @@ class Keyword implements KeywordContract
             $this->value,
             $this->wildcardCharacter,
             $this->wildcardReplacement,
-            $this->wildcardSearching ?? true
+            $this->wildcardSearching ?? true,
+            $this->wildcardSearchVariants ?? null
         );
     }
 
@@ -94,8 +95,13 @@ class Keyword implements KeywordContract
     /**
      * Convert basic string to searchable result.
      */
-    public static function searchable(string $text, ?string $wildcard = '*', ?string $replacement = '%', bool $wildcardSearching = true): array
-    {
+    public static function searchable(
+        string $text,
+        ?string $wildcard = '*',
+        ?string $replacement = '%',
+        bool $wildcardSearching = true,
+        ?array $wildcardSearchVariants = null
+    ): array {
         $text = static::sanitize($text);
 
         if (empty($text)) {
@@ -103,7 +109,7 @@ class Keyword implements KeywordContract
         } elseif (\is_null($replacement)) {
             return [$text];
         } elseif (! Str::contains($text, array_filter([$wildcard, $replacement])) && $wildcardSearching === true) {
-            return Collection::make(static::$defaultSearchVariations)
+            return Collection::make($wildcardSearchVariants ?? static::$defaultSearchVariations)
                 ->map(static function ($string) use ($text) {
                     return Str::replaceFirst('{keyword}', $text, $string);
                 })->all();

--- a/src/Searchable.php
+++ b/src/Searchable.php
@@ -60,6 +60,7 @@ class Searchable
 
         $keywords->wildcardCharacter($this->wildcardCharacter)
             ->wildcardReplacement($this->wildcardReplacement)
+            ->wildcardSearchVariants($this->wildcardSearchVariants)
             ->wildcardSearching($this->wildcardSearching ?? true);
 
         $likeOperator = like_operator(connection_type($query));
@@ -130,6 +131,7 @@ class Searchable
                 $this->searchKeyword()
                     ->wildcardCharacter($this->wildcardCharacter)
                     ->wildcardReplacement($this->wildcardReplacement)
+                    ->wildcardSearchVariants($this->wildcardSearchVariants)
                     ->wildcardSearching($field->wildcardSearching ?? $this->wildcardSearching ?? true)
                     ->handle($filter),
                 $likeOperator,
@@ -159,6 +161,7 @@ class Searchable
                 $this->searchKeyword()
                     ->wildcardCharacter($this->wildcardCharacter)
                     ->wildcardReplacement($this->wildcardReplacement)
+                    ->wildcardSearchVariants($this->wildcardSearchVariants)
                     ->wildcardSearching($field->wildcardSearching ?? $this->wildcardSearching ?? true)
                     ->handle($filter),
                 $likeOperator,
@@ -183,6 +186,7 @@ class Searchable
                 $this->searchKeyword()
                     ->wildcardCharacter($this->wildcardCharacter)
                     ->wildcardReplacement($this->wildcardReplacement)
+                    ->wildcardSearchVariants($this->wildcardSearchVariants)
                     ->wildcardSearching($field->wildcardSearching ?? $this->wildcardSearching ?? true)
                     ->handle($filter),
                 $likeOperator,

--- a/tests/Feature/EloquentSearchableTest.php
+++ b/tests/Feature/EloquentSearchableTest.php
@@ -44,6 +44,37 @@ class EloquentSearchableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_build_search_query_with_custom_search_variants()
+    {
+        UserFactory::new()->times(5)->create([
+            'name' => 'hello world',
+        ]);
+
+        UserFactory::new()->times(3)->create([
+            'name' => 'goodbye world',
+        ]);
+
+        $stub = (new Searchable(
+            'hello', ['name']
+        ))->wildcardSearchVariants(['%{keyword}%']);
+
+        $query = User::query();
+        $stub->apply($query);
+
+        $this->assertSame(
+            'select * from "users" where ("users"."name" like ?)',
+            $query->toSql()
+        );
+
+        $this->assertSame(
+            ['%hello%'],
+            $query->getBindings()
+        );
+
+        $this->assertSame(5, $query->count());
+    }
+
+    /** @test */
     public function it_can_build_search_query_with_combined_with_search_filters()
     {
         UserFactory::new()->times(5)->create([


### PR DESCRIPTION
```php
$searchable = (new Searchable('laravel', ['name'])->wildcardSearchVariants(['%{keyword}%']);
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>